### PR TITLE
Windows init fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Desktop.ini
 **/.idea/workspace.xml
 **/.idea/tasks.xml
 
+# VSCode
+.vscode/
+
 dist/
 
 lib-cov


### PR DESCRIPTION
On Windows the constructor gives an error if the SCardSvr service is disabled. This code changes the service's start type to auto so that it runs when a reader is connected, which makes the error go away