### PR TITLE
Keep in sync with santigimeno/node-pcsclite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run any code you will also need to have installed the pcsc daemon:
 
 ## Example
 
-```
+```js
 var pcsc = require('pcsclite');
 
 var pcsc = pcsc();

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -290,7 +290,7 @@ LONG PCSCLite::get_card_readers(PCSCLite* pcsclite, AsyncResult* async_result) {
         readers_name_length = 0;
 #ifndef SCARD_AUTOALLOCATE
         /* Retry in case of insufficient buffer error */
-        if (result == SCARD_E_INSUFFICIENT_BUFFER) {
+        if (result == (LONG)SCARD_E_INSUFFICIENT_BUFFER) {
             result = get_card_readers(pcsclite, async_result);
         }
 #endif


### PR DESCRIPTION
Review, reason and eventually merge these  changes:

- [ ] https://github.com/santigimeno/node-pcsclite/commit/a5a02f8e8223e030838961418f2c85f08922282a src: fix -Wsign-compare warning on OS X