### PR TITLE
Changed the nan require, this fix some building errors in certain linux distributions (E.g. Arch Linux)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
 					{
 						"include_dirs": [
 							"/usr/include/PCSC",
-							"<!(node -e \"require('nan')\")"
+							"<!(["node", "-e", "require(\'nan\')"])"
 						],
 						"link_settings": {
 							"libraries": [
@@ -42,7 +42,7 @@
 							"PCSC"
 						],
 						"include_dirs": [
-							"<!(node -e \"require('nan')\")"
+							"<!(["node", "-e", "require(\'nan\')"])"
 						]
 					}
 				],
@@ -53,7 +53,7 @@
 							"-lWinSCard"
 						],
 						"include_dirs": [
-							"<!(node -e \"require('nan')\")"
+							"<!(["node", "-e", "require(\'nan\')"])"
 						]
 					}
 				]


### PR DESCRIPTION
This fixes this issue:
`gyp: Call to 'node -e "require('nan')"' returned exit status 0 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:336:16)
gyp ERR! stack     at ChildProcess.emit (events.js:159:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:12)
gyp ERR! System Linux 4.14.11-1-ARCH
`