### PR TITLE
Allow initialization to fail if the program gets stuck in the postServiceCheck while-loop

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -1,7 +1,7 @@
 #include "pcsclite.h"
 #include "cardreader.h"
 
-void init_all(v8::Handle<v8::Object> target) {
+void init_all(v8::Local<v8::Object> target) {
     PCSCLite::init(target);
     CardReader::init(target);
 }

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -87,7 +87,7 @@ class CardReader: public Nan::ObjectWrap {
 
     public:
 
-        static void init(v8::Handle<v8::Object> target);
+        static void init(v8::Local<v8::Object> target);
 
         const SCARDHANDLE& GetHandler() const { return m_card_handle; };
 
@@ -120,7 +120,7 @@ class CardReader: public Nan::ObjectWrap {
         static void AfterTransmit(uv_work_t* req, int status);
         static void AfterControl(uv_work_t* req, int status);
 
-        static v8::Handle<v8::Value> CreateBufferInstance(char* data, unsigned long size);
+        static v8::Local<v8::Value> CreateBufferInstance(char* data, unsigned long size);
 
     private:
 

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -6,7 +6,9 @@ using namespace node;
 
 Nan::Persistent<Function> PCSCLite::constructor;
 
-void PCSCLite::init(Handle<Object> target) {
+void PCSCLite::init(Local<Object> target) {
+
+    Local<Context> context = Nan::GetCurrentContext();
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
@@ -16,8 +18,9 @@ void PCSCLite::init(Handle<Object> target) {
     Nan::SetPrototypeTemplate(tpl, "start", Nan::New<FunctionTemplate>(Start));
     Nan::SetPrototypeTemplate(tpl, "close", Nan::New<FunctionTemplate>(Close));
 
-    constructor.Reset(tpl->GetFunction());
-    target->Set(Nan::New("PCSCLite").ToLocalChecked(), tpl->GetFunction());
+
+    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
+    target->Set(Nan::New("PCSCLite").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
 }
 
 PCSCLite::PCSCLite(): m_card_context(0),

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -64,12 +64,17 @@ PCSCLite::PCSCLite(): m_card_context(0),
 
 postServiceCheck:
     LONG result;
+	int numRetries = 0;
     do {
         result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
                                             NULL,
                                             NULL,
                                             &m_card_context);
-    } while(result == SCARD_E_NO_SERVICE || result == SCARD_E_SERVICE_STOPPED);
+		if (result != SCARD_S_SUCCESS) {
+			numRetries++;
+			Sleep(750);
+		}
+    } while((result == SCARD_E_NO_SERVICE || result == SCARD_E_SERVICE_STOPPED) && numRetries < 3);
     if (result != SCARD_S_SUCCESS) {
         Nan::ThrowError(error_msg("SCardEstablishContext", result).c_str());
     } else {

--- a/src/pcsclite.h
+++ b/src/pcsclite.h
@@ -28,7 +28,7 @@ class PCSCLite: public Nan::ObjectWrap {
 
     public:
 
-        static void init(v8::Handle<v8::Object> target);
+        static void init(v8::Local<v8::Object> target);
 
     private:
 


### PR DESCRIPTION
Fix for #21. Adds a retry counter and allows the initialization of the library to fail. On Windows systems the smart card resource manager may be unresponsive or not running in case not readers are attached to the system. In that case the initialization will get stuck.