### PR TITLE
Fix and upgrade test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "mocha": "^6.0.0",
     "should": "^13.2.3",
-    "sinon": "^7.2.4"
+    "sinon": "^7.3.2"
   },
   "gypfile": true
 }

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe('Testing PCSCLite private', function() {
         it('#start() stub', function(done) {
             var self = this;
             var p = pcsc();
-            var stub = sinon.stub(p, 'start', function(my_cb) {
+            var stub = sinon.stub(p, 'start').callsFake(function(my_cb) {
                 var times = 0;
                 setInterval(function() {
                     switch (++ times) {
@@ -64,7 +64,7 @@ describe('Testing CardReader private', function() {
 
     var get_reader = function() {
         var p = pcsc();
-        var stub = sinon.stub(p, 'start', function(my_cb) {
+        var stub = sinon.stub(p, 'start').callsFake(function(my_cb) {
             /* "MyReader\0" */
             my_cb(undefined, new Buffer("MyReader\0"));
         });
@@ -77,7 +77,7 @@ describe('Testing CardReader private', function() {
         it('#_connect() success', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
-                var connect_stub = sinon.stub(reader, '_connect', function(share_mode,
+                var connect_stub = sinon.stub(reader, '_connect').callsFake(function(share_mode,
                                                                            protocol,
                                                                            connect_cb) {
                     connect_cb(undefined, 1);
@@ -95,7 +95,7 @@ describe('Testing CardReader private', function() {
             var p = get_reader();
             p.on('reader', function(reader) {
                 var cb = sinon.spy();
-                var connect_stub = sinon.stub(reader, '_connect', function(share_mode,
+                var connect_stub = sinon.stub(reader, '_connect').callsFake(function(share_mode,
                                                                            protocol,
                                                                            connect_cb) {
                     connect_cb("");
@@ -128,7 +128,7 @@ describe('Testing CardReader private', function() {
             p.on('reader', function(reader) {
                 reader.connected = true;
                 var cb = sinon.spy();
-                var connect_stub = sinon.stub(reader, '_disconnect', function(disposition,
+                var connect_stub = sinon.stub(reader, '_disconnect').callsFake(function(disposition,
                                                                               disconnect_cb) {
                     disconnect_cb(undefined);
                 });
@@ -143,7 +143,7 @@ describe('Testing CardReader private', function() {
             p.on('reader', function(reader) {
                 reader.connected = true;
                 var cb = sinon.spy();
-                var connect_stub = sinon.stub(reader, '_disconnect', function(disposition,
+                var connect_stub = sinon.stub(reader, '_disconnect').callsFake(function(disposition,
                                                                               disconnect_cb) {
                     disconnect_cb("");
                 });
@@ -157,7 +157,7 @@ describe('Testing CardReader private', function() {
             var p = get_reader();
             p.on('reader', function(reader) {
                 var cb = sinon.spy();
-                var connect_stub = sinon.stub(reader, '_disconnect', function(disposition,
+                var connect_stub = sinon.stub(reader, '_disconnect').callsFake(function(disposition,
                                                                               disconnect_cb) {
                     disconnect_cb(undefined);
                 });

--- a/test/test.js
+++ b/test/test.js
@@ -17,16 +17,16 @@ describe('Testing PCSCLite private', function() {
                 setInterval(function() {
                     switch (++ times) {
                         case 1:
-                            my_cb(undefined, new Buffer("MyReader\0"));
+                            my_cb(undefined, Buffer.from("MyReader\0"));
                             self.clock.tick(1000);
                         break;
 
                         case 2:
-                            my_cb(undefined, new Buffer("MyReader"));
+                            my_cb(undefined, Buffer.from("MyReader"));
                         break;
 
                         case 3:
-                            my_cb(undefined, new Buffer("MyReader1\0MyReader2\0"));
+                            my_cb(undefined, Buffer.from("MyReader1\0MyReader2\0"));
                         break;
                     }
                 }, 1000);
@@ -66,7 +66,7 @@ describe('Testing CardReader private', function() {
         var p = pcsc();
         var stub = sinon.stub(p, 'start').callsFake(function(my_cb) {
             /* "MyReader\0" */
-            my_cb(undefined, new Buffer("MyReader\0"));
+            my_cb(undefined, Buffer.from("MyReader\0"));
         });
 
         return p;

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe('Testing CardReader private', function() {
         var p = pcsc();
         var stub = sinon.stub(p, 'start').callsFake(function(my_cb) {
             /* "MyReader\0" */
-            my_cb(undefined, Buffer.from("MyReader\0"));
+            my_cb(undefined, Buffer.from("MyReader\u0000\u0000"));
         });
 
         return p;

--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ describe('Testing CardReader private', function() {
             });
         });
 
-        it('#_connect() error', function() {
+        it('#_connect() error', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
                 var cb = sinon.spy();
@@ -76,10 +76,11 @@ describe('Testing CardReader private', function() {
 
                 reader.connect(cb);
                 sinon.assert.calledOnce(cb);
+                done();
             });
         });
 
-        it('#_connect() already connected', function() {
+        it('#_connect() already connected', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
                 var cb = sinon.spy();
@@ -88,6 +89,7 @@ describe('Testing CardReader private', function() {
                 reader.connect(cb);
                 process.nextTick(function () {
                     sinon.assert.calledOnce(cb);
+                    done();
                 });
             });
         });
@@ -96,7 +98,7 @@ describe('Testing CardReader private', function() {
 
     describe('#_disconnect()', function() {
 
-        it('#_disconnect() success', function() {
+        it('#_disconnect() success', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
                 reader.connected = true;
@@ -108,10 +110,11 @@ describe('Testing CardReader private', function() {
 
                 reader.disconnect(cb);
                 sinon.assert.calledOnce(cb);
+                done();
             });
         });
 
-        it('#_disconnect() error', function() {
+        it('#_disconnect() error', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
                 reader.connected = true;
@@ -123,10 +126,11 @@ describe('Testing CardReader private', function() {
 
                 reader.disconnect(cb);
                 sinon.assert.calledOnce(cb);
+                done();
             });
         });
 
-        it('#_disconnect() already disconnected', function() {
+        it('#_disconnect() already disconnected', function(done) {
             var p = get_reader();
             p.on('reader', function(reader) {
                 var cb = sinon.spy();
@@ -138,6 +142,7 @@ describe('Testing CardReader private', function() {
                 reader.disconnect(cb);
                 process.nextTick(function () {
                     sinon.assert.calledOnce(cb);
+                    done();
                 });
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,14 @@
 # yarn lockfile v1
 
 
-"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.0.2":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
   integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
@@ -16,6 +23,14 @@
   dependencies:
     "@sinonjs/samsam" "^2 || ^3"
 
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
 "@sinonjs/samsam@^2 || ^3":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
@@ -25,10 +40,10 @@
     array-from "^2.1.1"
     lodash.get "^4.4.2"
 
-"@sinonjs/samsam@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.1.1.tgz#8e2eceb2353f6626e2867352e3def951d3366240"
-  integrity sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
+  integrity sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
   dependencies:
     "@sinonjs/commons" "^1.0.2"
     array-from "^2.1.1"
@@ -852,10 +867,10 @@ lolex@^2.3.2:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
   integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
-lolex@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
-  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
+lolex@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.1.0.tgz#ecdd7b86539391d8237947a3419aa8ac975f0fe1"
+  integrity sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -1306,16 +1321,16 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-sinon@^7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.4.tgz#d834b9a38d8533b4ca3274a9a9ffa8e54c95d10c"
-  integrity sha512-FGlcfrkiBRfaEIKRw8s/9mk4nP4AMGswvKFixLo+AzsOhskjaBCHAHGLMd8pCJpQGS+9ZI71px6qoQUyvADeyA==
+sinon@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"
+  integrity sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==
   dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    "@sinonjs/formatio" "^3.1.0"
-    "@sinonjs/samsam" "^3.1.1"
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.1"
     diff "^3.5.0"
-    lolex "^3.1.0"
+    lolex "^4.0.1"
     nise "^1.4.10"
     supports-color "^5.5.0"
 


### PR DESCRIPTION
When running `yarn test` on Windows 10 x64, with Node v10.15.3, the current version of `node-pcsclite` produces the following error:

    TypeError: stub(obj, 'meth', fn) has been removed, see documentation

This causes all tests to fail on my system. This is related to a deprecation / API change in Sinon:
https://github.com/sinonjs/sinon/issues/1761#issuecomment-386034296

Some other things I've noticed:
- The "start" and "connect" tests fail due to a timeout (they seem to be incomplete).
- There is a Buffer deprecation warning (as of Node v10).
- Mocha seems to hang after running the tests instead of exiting cleanly.

---

This PR addresses issues with the test suite by:
- Applying [sinon-codemod/extract-calls-fake](https://github.com/hurrymaplelad/sinon-codemod) to `test.js`.
- Upgrading the `sinon` dependency in `package.json` to `^7.3.2` (latest release).
- Updating the `new Buffer()` calls to `Buffer.from()`.
- Rewriting the "#start()" test so it makes sense, with sample data based on the example in `pcsc.js`.
- Modifying the `get_reader()` test helper so it uses the correct end marker for reader names (fixes the "#connect()" test).
- Tests: Add explicit done() calls all round to ensure the tests actually complete as expected.