### PR TITLE
Node 12 fixes follow-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "bindings": "^1.4.0",
-    "nan": "^2.12.1"
+    "bindings": "^1.5.0",
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "mocha": "^6.0.0",

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -58,10 +58,8 @@ void CardReader::init(Local<Object> target) {
     Nan::SetPrototypeTemplate(tpl, "SCARD_UNPOWER_CARD", Nan::New(SCARD_UNPOWER_CARD));
     Nan::SetPrototypeTemplate(tpl, "SCARD_EJECT_CARD", Nan::New(SCARD_EJECT_CARD));
 
-    Local <Context> context = Nan::GetCurrentContext();
-
-    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
-    target->Set(Nan::New("CardReader").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
+    constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    target->Set(Nan::New("CardReader").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 CardReader::CardReader(const std::string &reader_name): m_card_context(0),
@@ -136,11 +134,9 @@ NAN_METHOD(CardReader::Connect) {
         return Nan::ThrowError("Third argument must be a callback function");
     }
 
-    Local<Context> context = Nan::GetCurrentContext();
-
     ConnectInput* ci = new ConnectInput();
-    ci->share_mode = info[0]->Uint32Value(context).FromJust();
-    ci->pref_protocol = info[1]->Uint32Value(context).FromJust();
+    ci->share_mode = Nan::To<uint32_t>(info[0]).FromJust();
+    ci->pref_protocol = Nan::To<uint32_t>(info[1]).FromJust();
     Local<Function> cb = Local<Function>::Cast(info[2]);
 
     // This creates our work request, including the libuv struct.
@@ -174,9 +170,7 @@ NAN_METHOD(CardReader::Disconnect) {
         return Nan::ThrowError("Second argument must be a callback function");
     }
 
-    Local<Context> context = Nan::GetCurrentContext();
-
-    DWORD disposition = info[0]->Uint32Value(context).FromJust();
+    DWORD disposition = Nan::To<uint32_t>(info[0]).FromJust();
     Local<Function> cb = Local<Function>::Cast(info[1]);
 
     // This creates our work request, including the libuv struct.
@@ -222,11 +216,9 @@ NAN_METHOD(CardReader::Transmit) {
         return Nan::ThrowError("Fourth argument must be a callback function");
     }
 
-    Local<Context> context = Nan::GetCurrentContext();
-
     Local<Object> buffer_data = Nan::To<Object>(info[0]).ToLocalChecked();
-    uint32_t out_len = info[1]->Uint32Value(context).FromJust();
-    uint32_t protocol = info[2]->Uint32Value(context).FromJust();
+    uint32_t out_len = Nan::To<uint32_t>(info[1]).FromJust();
+    uint32_t protocol = Nan::To<uint32_t>(info[2]).FromJust();
 
     Local<Function> cb = Local<Function>::Cast(info[3]);
 
@@ -280,10 +272,8 @@ NAN_METHOD(CardReader::Control) {
         return Nan::ThrowError("Fourth argument must be a callback function");
     }
 
-	Local<Context> context = Nan::GetCurrentContext();
-
     Local<Object> in_buf = Nan::To<Object>(info[0]).ToLocalChecked();
-    DWORD control_code = info[1]->Uint32Value(context).FromJust();
+    DWORD control_code = Nan::To<uint32_t>(info[1]).FromJust();
     Local<Object> out_buf = Nan::To<Object>(info[2]).ToLocalChecked();
     Local<Function> cb = Local<Function>::Cast(info[3]);
 

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -59,7 +59,7 @@ void CardReader::init(Local<Object> target) {
     Nan::SetPrototypeTemplate(tpl, "SCARD_EJECT_CARD", Nan::New(SCARD_EJECT_CARD));
 
     constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
-    target->Set(Nan::New("CardReader").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+    Nan::Set(target, Nan::New("CardReader").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 CardReader::CardReader(const std::string &reader_name): m_card_context(0),
@@ -92,8 +92,8 @@ NAN_METHOD(CardReader::New) {
 
     CardReader* obj = new CardReader(*reader_name);
     obj->Wrap(info.Holder());
-    obj->handle()->Set(Nan::New(name_symbol), Nan::To<String>(info[0]).ToLocalChecked());
-    obj->handle()->Set(Nan::New(connected_symbol), Nan::False());
+    Nan::Set(obj->handle(), Nan::New(name_symbol), Nan::To<String>(info[0]).ToLocalChecked());
+    Nan::Set(obj->handle(), Nan::New(connected_symbol), Nan::False());
 
     info.GetReturnValue().Set(info.Holder());
 }
@@ -478,7 +478,7 @@ void CardReader::AfterConnect(uv_work_t* req, int status) {
         Local<Value> argv[argc] = { err };
         Nan::Callback(Nan::New(baton->callback)).Call(argc, argv);
     } else {
-        baton->reader->handle()->Set(Nan::New(connected_symbol), Nan::True());
+        Nan::Set(baton->reader->handle(), Nan::New(connected_symbol), Nan::True());
         const unsigned argc = 2;
         Local<Value> argv[argc] = {
             Nan::Null(),
@@ -533,7 +533,7 @@ void CardReader::AfterDisconnect(uv_work_t* req, int status) {
         Local<Value> argv[argc] = { err };
         Nan::Callback(Nan::New(baton->callback)).Call(argc, argv);
     } else {
-        baton->reader->handle()->Set(Nan::New(connected_symbol), Nan::False());
+        Nan::Set(baton->reader->handle(), Nan::New(connected_symbol), Nan::False());
         const unsigned argc = 1;
         Local<Value> argv[argc] = {
             Nan::Null()

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -331,7 +331,7 @@ NAN_METHOD(CardReader::Close) {
     info.GetReturnValue().Set(Nan::New<Number>(result));
 }
 
-void CardReader::HandleReaderStatusChange(uv_async_t *handle, int status) {
+void CardReader::HandleReaderStatusChange(uv_async_t *handle) {
 
     Nan::HandleScope scope;
 

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -107,7 +107,7 @@ class CardReader: public Nan::ObjectWrap {
         static NAN_METHOD(Control);
         static NAN_METHOD(Close);
 
-        static void HandleReaderStatusChange(uv_async_t *handle, int status);
+        static void HandleReaderStatusChange(uv_async_t *handle);
         static void HandlerFunction(void* arg);
         static void DoConnect(uv_work_t* req);
         static void DoDisconnect(uv_work_t* req);

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -132,6 +132,7 @@ class CardReader: public Nan::ObjectWrap {
         uv_mutex_t m_mutex;
         uv_cond_t m_cond;
         int m_state;
+        static Nan::AsyncResource *async_resource;
 };
 
 #endif /* CARDREADER_H */

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -18,7 +18,7 @@ void PCSCLite::init(Local<Object> target) {
 
 
     constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
-    target->Set(Nan::New("PCSCLite").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+    Nan::Set(target, Nan::New("PCSCLite").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 PCSCLite::PCSCLite(): m_card_context(0),

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -6,6 +6,8 @@ using namespace node;
 
 Nan::Persistent<Function> PCSCLite::constructor;
 
+Nan::AsyncResource *PCSCLite::async_resource = new Nan::AsyncResource("PCSCLite_StaticAsyncResource");
+
 void PCSCLite::init(Local<Object> target) {
 
     // Prepare constructor template
@@ -181,10 +183,10 @@ void PCSCLite::HandleReaderStatusChange(uv_async_t *handle, int status) {
             Nan::CopyBuffer(ar->readers_name, ar->readers_name_length).ToLocalChecked()
         };
 
-        Nan::Callback(Nan::New(async_baton->callback)).Call(argc, argv);
+        Nan::Callback(Nan::New(async_baton->callback)).Call(argc, argv, async_resource);
     } else {
         Local<Value> argv[1] = { Nan::Error(ar->err_msg.c_str()) };
-        Nan::Callback(Nan::New(async_baton->callback)).Call(1, argv);
+        Nan::Callback(Nan::New(async_baton->callback)).Call(1, argv, async_resource);
     }
 
     // Do exit, after throwing last events

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -63,9 +63,9 @@ PCSCLite::PCSCLite(): m_card_context(0),
         WaitForSingleObject(seInfo.hProcess, INFINITE);
         CloseHandle(seInfo.hProcess);
     }
+postServiceCheck:
 #endif // _WIN32
 
-postServiceCheck:
     LONG result;
     do {
         result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
@@ -166,7 +166,7 @@ NAN_METHOD(PCSCLite::Close) {
     info.GetReturnValue().Set(Nan::New<Number>(result));
 }
 
-void PCSCLite::HandleReaderStatusChange(uv_async_t *handle, int status) {
+void PCSCLite::HandleReaderStatusChange(uv_async_t *handle) {
 
     Nan::HandleScope scope;
 

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -8,8 +8,6 @@ Nan::Persistent<Function> PCSCLite::constructor;
 
 void PCSCLite::init(Local<Object> target) {
 
-    Local<Context> context = Nan::GetCurrentContext();
-
     // Prepare constructor template
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
     tpl->SetClassName(Nan::New("PCSCLite").ToLocalChecked());
@@ -19,8 +17,8 @@ void PCSCLite::init(Local<Object> target) {
     Nan::SetPrototypeTemplate(tpl, "close", Nan::New<FunctionTemplate>(Close));
 
 
-    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
-    target->Set(Nan::New("PCSCLite").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
+    constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    target->Set(Nan::New("PCSCLite").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 PCSCLite::PCSCLite(): m_card_context(0),

--- a/src/pcsclite.h
+++ b/src/pcsclite.h
@@ -56,6 +56,7 @@ class PCSCLite: public Nan::ObjectWrap {
         uv_cond_t m_cond;
         bool m_pnp;
         int m_state;
+        static Nan::AsyncResource *async_resource;
 };
 
 #endif /* PCSCLITE_H */

--- a/src/pcsclite.h
+++ b/src/pcsclite.h
@@ -41,7 +41,7 @@ class PCSCLite: public Nan::ObjectWrap {
         static NAN_METHOD(Start);
         static NAN_METHOD(Close);
 
-        static void HandleReaderStatusChange(uv_async_t *handle, int status);
+        static void HandleReaderStatusChange(uv_async_t *handle);
         static void HandlerFunction(void* arg);
         static void CloseCallback(uv_handle_t *handle);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,10 +70,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-bindings@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.4.0.tgz#909efa49f2ebe07ecd3cb136778f665052040127"
-  integrity sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
 
@@ -428,10 +428,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nise@^1.5.2:
   version "1.5.3"


### PR DESCRIPTION
**Now working with Node.js versions `8.x` up to `13.x`!**

- update to `Bindings` 1.5.0
- update to `Nan` 2.14.0
- use `Nan::To<>` for type conversions
- use `Nan::GetFunction` and `Nan::Set` to retain cross-compatibility 
- provide `Nan::AsyncResource` to callback as required by new version of Nan library
- fix all compiler warnings

There are currently no compiler warnings and code uses no deprecated functions anymore. :tada: 

Fixes #24 
Fixes pokusew/nfc-pcsc#81
Fixes pokusew/nfc-pcsc#86
Fixes pokusew/nfc-pcsc#91
Fixes pokusew/nfc-pcsc#92