### PR TITLE
Confirm support for Node.js 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        node: [8.x, 10.x, 12.x, 13.x]
+        node: [8.x, 10.x, 12.x, 13.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ After reboot, there will be no driver blocking the usb bus anymore, so we can fi
 
 ### Which Node.js versions are supported?
 
-@pokusew/pcsclite officially supports the following Node.js versions: **8.x, 9.x, 10.x, 11.x, 12.x, 13.x**.
+@pokusew/pcsclite officially supports the following Node.js versions: **8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x**.
 
 ### Can I use this library in my React Native app?
 


### PR DESCRIPTION
No changes are needed for supporting Node.js 14.x.
Updated README and added CI check.