### PR TITLE
Export interfaces and types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
 import { EventEmitter } from "events";
 
-type ConnectOptions = {
+export type ConnectOptions = {
 	share_mode?: number;
 	protocol?: number;
 };
 
-type Status = {
-	atr?: Buffer;
+export type Status = {
+	atr?:  Buffer;
 	state: number;
 };
 
 type AnyOrNothing = any | undefined | null;
 
-interface PCSCLite extends EventEmitter {
+export interface PCSCLite extends EventEmitter {
 	on(type: "error", listener: (error: any) => void): this;
 
 	once(type: "error", listener: (error: any) => void): this;
@@ -24,7 +24,7 @@ interface PCSCLite extends EventEmitter {
 	close(): void;
 }
 
-interface CardReader extends EventEmitter {
+export interface CardReader extends EventEmitter {
 	// Share Mode
 	SCARD_SHARE_SHARED: number;
 	SCARD_SHARE_EXCLUSIVE: number;
@@ -106,6 +106,4 @@ interface CardReader extends EventEmitter {
 	close(): void;
 }
 
-declare function pcsc(): PCSCLite;
-
-export = pcsc;
+export default function pcsc(): PCSCLite;


### PR DESCRIPTION
I've exported the types and interfaces. So they can be imported, and used within a project.

My reason for this is, that I need to put the readers in an array, for later use.
```typescript
import pcsclite, { CardReader } from '@pokusew/node-pcsclite'

const pcsc = pcsclite()
const readers: CardReader[] = []

pcsc.on('reader', (reader) => {
  readers.push(reader)
})
```