### PR TITLE
fix: avoid endless loop when SCardEstablishContext is not successful

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokusew/pcsclite",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bindings over PC/SC to access Smart Cards",
   "keywords": [
     "nfc",

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -69,13 +69,18 @@ postServiceCheck:
 
     LONG result;
     // TODO: consider removing this do-while Windows workaround that should not be needed anymore
+	INT retry = 0;
     do {
+		if (retry > 0) {
+			Sleep(100 * retry);
+		}
+
         // TODO: make dwScope (now hard-coded to SCARD_SCOPE_SYSTEM) customisable
         result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
                                             NULL,
                                             NULL,
                                             &m_card_context);
-    } while(result == SCARD_E_NO_SERVICE || result == SCARD_E_SERVICE_STOPPED);
+    } while((result == SCARD_E_NO_SERVICE || result == SCARD_E_SERVICE_STOPPED) && retry++ < 3);
     if (result != SCARD_S_SUCCESS) {
         Nan::ThrowError(error_msg("SCardEstablishContext", result).c_str());
     } else {

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -67,20 +67,12 @@ PCSCLite::PCSCLite(): m_card_context(0),
 postServiceCheck:
 #endif // _WIN32
 
-    LONG result;
-    // TODO: consider removing this do-while Windows workaround that should not be needed anymore
-	INT retry = 0;
-    do {
-		if (retry > 0) {
-			Sleep(100 * retry);
-		}
+    // TODO: make dwScope (now hard-coded to SCARD_SCOPE_SYSTEM) customisable
+    LONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
+                                        NULL,
+                                        NULL,
+                                        &m_card_context);
 
-        // TODO: make dwScope (now hard-coded to SCARD_SCOPE_SYSTEM) customisable
-        result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
-                                            NULL,
-                                            NULL,
-                                            &m_card_context);
-    } while((result == SCARD_E_NO_SERVICE || result == SCARD_E_SERVICE_STOPPED) && retry++ < 3);
     if (result != SCARD_S_SUCCESS) {
         Nan::ThrowError(error_msg("SCardEstablishContext", result).c_str());
     } else {


### PR DESCRIPTION
We encountered that on systems that have never connected any smart card readers, the application runs on 100%; the reason is the while loop around the SCardEstablishContext