### PR TITLE
fix build on windows for ia32

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -54,6 +54,9 @@
 						],
 						"include_dirs": [
 							"<!(node -e \"require('nan')\")"
+						],
+						"defines": [
+							"NOMINMAX"
 						]
 					}
 				]


### PR DESCRIPTION
When building my electron app with @pokusew/node-pcsclite, I had an error on windows (same as this one : https://github.com/prebuild/node-gyp-build/issues/70)

It is fixed with this PR, following this comment https://github.com/electron/electron/issues/40760#issuecomment-1979048889